### PR TITLE
Implement CRUD operations for usuario

### DIFF
--- a/springboot/demo/src/main/java/com/example/demo/api/controller/UsuarioController.java
+++ b/springboot/demo/src/main/java/com/example/demo/api/controller/UsuarioController.java
@@ -1,4 +1,46 @@
 package com.example.demo.api.controller;
 
+import com.example.demo.api.dto.UsuarioDTO;
+import com.example.demo.api.service.UsuarioService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+
+@RestController
+@RequestMapping("/api/usuario")
+@RequiredArgsConstructor
 public class UsuarioController {
+
+    private final UsuarioService usuarioService;
+
+    @GetMapping
+    public ResponseEntity<List<UsuarioDTO>> listarTodos() {
+        return ResponseEntity.ok(usuarioService.listarTodos());
+    }
+
+    @GetMapping("/{id}")
+    public ResponseEntity<UsuarioDTO> buscarPorId(@PathVariable Integer id) {
+        return ResponseEntity.ok(usuarioService.buscarPorId(id));
+    }
+
+    @PostMapping
+    public ResponseEntity<UsuarioDTO> criar(@RequestBody UsuarioDTO usuarioDTO) {
+        UsuarioDTO criado = usuarioService.criar(usuarioDTO);
+        return ResponseEntity.status(HttpStatus.CREATED).body(criado);
+    }
+
+    @PutMapping("/{id}")
+    public ResponseEntity<UsuarioDTO> atualizar(@PathVariable Integer id,
+                                                @RequestBody UsuarioDTO usuarioDTO) {
+        return ResponseEntity.ok(usuarioService.atualizar(id, usuarioDTO));
+    }
+
+    @DeleteMapping("/{id}")
+    public ResponseEntity<Void> deletar(@PathVariable Integer id) {
+        usuarioService.deletar(id);
+        return ResponseEntity.noContent().build();
+    }
 }

--- a/springboot/demo/src/main/java/com/example/demo/api/service/UsuarioService.java
+++ b/springboot/demo/src/main/java/com/example/demo/api/service/UsuarioService.java
@@ -1,4 +1,84 @@
 package com.example.demo.api.service;
 
+import com.example.demo.api.dto.UsuarioDTO;
+import com.example.demo.api.model.UsuarioEntity;
+import com.example.demo.api.repository.UsuarioRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.server.ResponseStatusException;
+
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
 public class UsuarioService {
+
+    private final UsuarioRepository usuarioRepository;
+
+    @Transactional(readOnly = true)
+    public List<UsuarioDTO> listarTodos() {
+        return usuarioRepository.findAll()
+                .stream()
+                .map(this::mapearParaDTO)
+                .toList();
+    }
+
+    @Transactional(readOnly = true)
+    public UsuarioDTO buscarPorId(Integer id) {
+        UsuarioEntity entity = usuarioRepository.findById(id)
+                .orElseThrow(() -> new ResponseStatusException(HttpStatus.NOT_FOUND, "Usuário não encontrado"));
+        return mapearParaDTO(entity);
+    }
+
+    @Transactional
+    public UsuarioDTO criar(UsuarioDTO usuarioDTO) {
+        UsuarioEntity entity = new UsuarioEntity();
+        aplicarValores(entity, usuarioDTO);
+        UsuarioEntity salvo = usuarioRepository.save(entity);
+        return mapearParaDTO(salvo);
+    }
+
+    @Transactional
+    public UsuarioDTO atualizar(Integer id, UsuarioDTO usuarioDTO) {
+        UsuarioEntity existente = usuarioRepository.findById(id)
+                .orElseThrow(() -> new ResponseStatusException(HttpStatus.NOT_FOUND, "Usuário não encontrado"));
+
+        aplicarValores(existente, usuarioDTO);
+        UsuarioEntity atualizado = usuarioRepository.save(existente);
+        return mapearParaDTO(atualizado);
+    }
+
+    @Transactional
+    public void deletar(Integer id) {
+        if (!usuarioRepository.existsById(id)) {
+            throw new ResponseStatusException(HttpStatus.NOT_FOUND, "Usuário não encontrado");
+        }
+
+        usuarioRepository.deleteById(id);
+    }
+
+    private UsuarioDTO mapearParaDTO(UsuarioEntity entity) {
+        if (entity == null) {
+            return null;
+        }
+
+        return UsuarioDTO.builder()
+                .codigoUsuario(entity.getCodigoUsuario())
+                .email(entity.getEmail())
+                .senha(entity.getSenha())
+                .pontuacao(entity.getPontuacao())
+                .build();
+    }
+
+    private void aplicarValores(UsuarioEntity entity, UsuarioDTO dto) {
+        if (dto == null) {
+            return;
+        }
+
+        entity.setEmail(dto.getEmail());
+        entity.setSenha(dto.getSenha());
+        entity.setPontuacao(dto.getPontuacao());
+    }
 }


### PR DESCRIPTION
## Summary
- implement UsuarioService with CRUD operations using UsuarioRepository and DTO mapping
- expose REST endpoints in UsuarioController for listing, retrieving, creating, updating, and deleting usuarios

## Testing
- `./mvnw test` *(fails: network is unreachable while downloading Maven wrapper dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_68e1506f50c483209acc40656c7a7c67