### PR TITLE
Fix Spring Boot datasource initialization configuration

### DIFF
--- a/springboot/demo/src/main/resources/application.properties
+++ b/springboot/demo/src/main/resources/application.properties
@@ -15,14 +15,9 @@ spring.jpa.database-platform=org.hibernate.dialect.MySQLDialect
 spring.jpa.show-sql=true
 spring.jpa.properties.hibernate.format_sql=true
 spring.jpa.hibernate.naming.physical-strategy=org.hibernate.boot.model.naming.PhysicalNamingStrategyStandardImpl
-<<<<<<< HEAD
 
-# Init
-spring.sql.init.mode=never
-=======
 # Executa sempre o schema.sql para garantir a criação das tabelas dependentes
 spring.sql.init.mode=always
->>>>>>> e33294f058e0db74c5808a1abff43064d26c90b7
 spring.jpa.defer-datasource-initialization=true
 
 # (Opcional) Pool menor para ambientes com pouca RAM

--- a/springboot/demo/target/classes/application.properties
+++ b/springboot/demo/target/classes/application.properties
@@ -15,14 +15,9 @@ spring.jpa.database-platform=org.hibernate.dialect.MySQLDialect
 spring.jpa.show-sql=true
 spring.jpa.properties.hibernate.format_sql=true
 spring.jpa.hibernate.naming.physical-strategy=org.hibernate.boot.model.naming.PhysicalNamingStrategyStandardImpl
-<<<<<<< HEAD
 
-# Init
-spring.sql.init.mode=never
-=======
 # Executa sempre o schema.sql para garantir a criação das tabelas dependentes
 spring.sql.init.mode=always
->>>>>>> e33294f058e0db74c5808a1abff43064d26c90b7
 spring.jpa.defer-datasource-initialization=true
 
 # (Opcional) Pool menor para ambientes com pouca RAM


### PR DESCRIPTION
## Summary
- resolve leftover merge conflict markers in the main Spring Boot application properties
- keep schema initialization enabled so the MySQL schema is created automatically at container startup

## Testing
- `./mvnw -q test` *(fails: Maven wrapper cannot download dependencies because the network is unreachable in the execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68e1516fdc488320ba2bc50052b6f192