### PR TITLE
Add user login endpoint

### DIFF
--- a/springboot/demo/src/main/java/com/example/demo/api/controller/UsuarioController.java
+++ b/springboot/demo/src/main/java/com/example/demo/api/controller/UsuarioController.java
@@ -1,5 +1,6 @@
 package com.example.demo.api.controller;
 
+import com.example.demo.api.dto.LoginRequestDTO;
 import com.example.demo.api.dto.UsuarioDTO;
 import com.example.demo.api.service.UsuarioService;
 import lombok.RequiredArgsConstructor;
@@ -30,6 +31,11 @@ public class UsuarioController {
     public ResponseEntity<UsuarioDTO> criar(@RequestBody UsuarioDTO usuarioDTO) {
         UsuarioDTO criado = usuarioService.criar(usuarioDTO);
         return ResponseEntity.status(HttpStatus.CREATED).body(criado);
+    }
+
+    @PostMapping("/login")
+    public ResponseEntity<UsuarioDTO> login(@RequestBody LoginRequestDTO loginRequest) {
+        return ResponseEntity.ok(usuarioService.autenticar(loginRequest));
     }
 
     @PutMapping("/{id}")

--- a/springboot/demo/src/main/java/com/example/demo/api/dto/LoginRequestDTO.java
+++ b/springboot/demo/src/main/java/com/example/demo/api/dto/LoginRequestDTO.java
@@ -1,0 +1,16 @@
+package com.example.demo.api.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+public class LoginRequestDTO {
+
+    private String email;
+    private String senha;
+}

--- a/springboot/demo/src/main/java/com/example/demo/api/repository/UsuarioRepository.java
+++ b/springboot/demo/src/main/java/com/example/demo/api/repository/UsuarioRepository.java
@@ -4,5 +4,9 @@ package com.example.demo.api.repository;
 import com.example.demo.api.model.UsuarioEntity;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.Optional;
+
 public interface UsuarioRepository extends JpaRepository<UsuarioEntity, Integer> {
+
+    Optional<UsuarioEntity> findByEmailAndSenha(String email, String senha);
 }

--- a/springboot/demo/src/main/java/com/example/demo/api/service/UsuarioService.java
+++ b/springboot/demo/src/main/java/com/example/demo/api/service/UsuarioService.java
@@ -1,5 +1,6 @@
 package com.example.demo.api.service;
 
+import com.example.demo.api.dto.LoginRequestDTO;
 import com.example.demo.api.dto.UsuarioDTO;
 import com.example.demo.api.model.UsuarioEntity;
 import com.example.demo.api.repository.UsuarioRepository;
@@ -57,6 +58,14 @@ public class UsuarioService {
         }
 
         usuarioRepository.deleteById(id);
+    }
+
+    @Transactional(readOnly = true)
+    public UsuarioDTO autenticar(LoginRequestDTO loginRequest) {
+        UsuarioEntity usuario = usuarioRepository.findByEmailAndSenha(loginRequest.getEmail(), loginRequest.getSenha())
+                .orElseThrow(() -> new ResponseStatusException(HttpStatus.UNAUTHORIZED, "Credenciais inválidas"));
+
+        return mapearParaDTO(usuario);
     }
 
     private UsuarioDTO mapearParaDTO(UsuarioEntity entity) {


### PR DESCRIPTION
## Summary
- add DTO and repository query to fetch users by email and password
- expose a login endpoint that returns user information when credentials are valid
- reuse service layer to authenticate users and return existing DTO

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68e1b55dfa5083209347acf58374bf82