### PR TITLE
Integrate React frontend with Spring API endpoints

### DIFF
--- a/front/src/Cadastro.js
+++ b/front/src/Cadastro.js
@@ -1,20 +1,7 @@
 import { useState } from "react";
 import { useNavigate, Link } from "react-router-dom";
-import "./Login.css"; 
-
-
-async function jsonPost(url, body) {
-  const res = await fetch(url, {
-    method: "POST",
-    headers: { "Content-Type": "application/json" },
-    body: JSON.stringify(body || {}),
-  });
-  const text = await res.text();
-  let data = null;
-  try { data = text ? JSON.parse(text) : null; } catch { data = { raw: text }; }
-  if (!res.ok) throw new Error(`HTTP ${res.status}: ${text}`);
-  return data;
-}
+import { api } from "./api";
+import "./Login.css";
 
 export default function Cadastro() {
   const [name, setName] = useState("");
@@ -27,7 +14,8 @@ export default function Cadastro() {
   const navigate = useNavigate();
 
   async function doRegister(mode) {
-    setErr(""); setOk("");
+    setErr("");
+    setOk("");
 
     if (!name || !emailReg || !passReg || !passReg2) {
       setErr("Preencha todos os campos.");
@@ -37,34 +25,21 @@ export default function Cadastro() {
       setErr("As senhas não coincidem.");
       return;
     }
-
-    
-    const prefix = mode === "grpc" ? "/grpc" : "/rest";
-
     try {
-      
-      
-      await jsonPost(`${prefix}/auth/register`, {
-        name,
+      await api.registrarUsuario({
         email: emailReg,
-        password: passReg,
+        senha: passReg,
+        pontuacao: 0,
       });
 
-      
-  localStorage.setItem("apiMode", mode);            
-      localStorage.setItem("basePrefix", prefix);
-      localStorage.setItem("demoUser", JSON.stringify({ name, email: emailReg }));
-
-      setOk(`Conta criada com sucesso via ${mode.toUpperCase()}!`);
-      setTimeout(() => navigate("/login", { replace: true }), 900);
-    } catch (e) {
-      
       localStorage.setItem("apiMode", mode);
-      localStorage.setItem("basePrefix", prefix);
+      localStorage.setItem("basePrefix", "/rest");
       localStorage.setItem("demoUser", JSON.stringify({ name, email: emailReg }));
 
-      setOk(`Conta criada (demo) via ${mode.toUpperCase()}.`);
+      setOk("Conta criada com sucesso!");
       setTimeout(() => navigate("/login", { replace: true }), 900);
+    } catch (error) {
+      setErr(error.message || "Não foi possível criar a conta.");
     }
   }
 

--- a/front/src/Login.js
+++ b/front/src/Login.js
@@ -1,5 +1,6 @@
 import { useState } from "react";
 import { useNavigate, useLocation, Link } from "react-router-dom";
+import { api } from "./api";
 import "./Login.css";
 
 export default function Login() {
@@ -12,24 +13,29 @@ export default function Login() {
   const location = useLocation();
   const next = location.state?.from?.pathname || "/quiz";
 
-  function doLogin(mode) {
-    setErr(""); setOk("");
+  async function doLogin(mode) {
+    setErr("");
+    setOk("");
 
     if (!email || !password) {
       setErr("Digite email e senha.");
       return;
     }
 
-    
-    localStorage.setItem("token", "demo-token");
-  localStorage.setItem("apiMode", mode);              
-    localStorage.setItem("basePrefix", mode === "grpc" ? "/grpc" : "/rest");
+    try {
+      const usuario = await api.login(email, password);
 
-    const guessedName = email.split("@")[0] || "Aluno(a)";
-    localStorage.setItem("userName", guessedName);
+      localStorage.setItem("token", String(usuario?.codigoUsuario ?? ""));
+      localStorage.setItem("apiMode", mode);
+      localStorage.setItem("basePrefix", "/rest");
+      localStorage.setItem("userName", usuario?.email?.split("@")?.[0] || "Aluno(a)");
+      localStorage.setItem("userId", String(usuario?.codigoUsuario ?? ""));
 
-    setOk(`Login realizado via ${mode.toUpperCase()}!`);
-    setTimeout(() => navigate(next, { replace: true }), 500);
+      setOk("Login realizado com sucesso!");
+      setTimeout(() => navigate(next, { replace: true }), 500);
+    } catch (error) {
+      setErr(error.message || "Não foi possível realizar o login.");
+    }
   }
 
   return (

--- a/front/src/QuizCRUD.js
+++ b/front/src/QuizCRUD.js
@@ -1,41 +1,6 @@
 import { useEffect, useMemo, useState } from "react";
+import { api } from "./api";
 import "./QuizCRUD.css";
-
-const REST_PREFIX = "/rest";
-const GRPC_PREFIX = "/grpc";
-
-
-function prefixFor(mode) {
-  return mode === "rest" ? REST_PREFIX : GRPC_PREFIX;
-}
-async function jsonFetch(url, { method = "GET", body, token } = {}) {
-  const headers = { "Content-Type": "application/json" };
-  if (token) headers["Authorization"] = `Bearer ${token}`;
-  const res = await fetch(url, { method, headers, body: body ? JSON.stringify(body) : undefined });
-  const text = await res.text();
-  let data = null;
-  try { data = text ? JSON.parse(text) : null; } catch { data = { raw: text }; }
-  if (!res.ok) throw new Error(`HTTP ${res.status}: ${text}`);
-  return data;
-}
-
-
-const DEMO_DATA = [
-  {
-    id: 1,
-    text: "O que é gRPC?",
-    options: ["Protocolo de roteamento", "Framework RPC", "Banco de dados", "Balanceador"],
-    correctIndex: 1,
-    explanation: "gRPC é um framework RPC de alto desempenho baseado em HTTP/2 e Protobuf.",
-  },
-  {
-    id: 2,
-    text: "Qual protocolo de transporte o gRPC usa por padrão?",
-    options: ["HTTP/1.1", "WebSocket", "HTTP/2", "FTP"],
-    correctIndex: 2,
-    explanation: "gRPC usa HTTP/2 por padrão.",
-  },
-];
 
 
 function ModeToggle({ mode, setMode }) {
@@ -126,48 +91,60 @@ function QuestionForm({ value, onChange, onSubmit, onCancel, submitting, mode })
 
 
 export default function QuizCRUD() {
-  const [mode, setMode] = useState("grpc");
+  const [mode, setMode] = useState("rest");
   const [items, setItems] = useState([]);
   const [q, setQ] = useState("");
   const [loading, setLoading] = useState(false);
   const [err, setErr] = useState("");
   const [editing, setEditing] = useState(null);
   const [submitting, setSubmitting] = useState(false);
-  const token = typeof localStorage !== "undefined" ? localStorage.getItem("token") || "" : "";
 
   async function load() {
-    setErr(""); setLoading(true);
+    setErr("");
+    setLoading(true);
     try {
-      const data = await jsonFetch(`${prefixFor(mode)}/quiz`, { token });
-      const arr = Array.isArray(data) ? data : (data?.items || []);
-      setItems(arr);
-    } catch {
-      setItems(DEMO_DATA);
-      setErr("(demo) usando dados locais, não consegui buscar no backend.");
-    } finally { setLoading(false); }
+      const data = await api.listarPerguntas();
+      setItems(data);
+    } catch (e) {
+      setItems([]);
+      setErr(e.message || "Não foi possível carregar as perguntas.");
+    } finally {
+      setLoading(false);
+    }
   }
 
   async function createItem(payload) {
     try {
-      const created = await jsonFetch(`${prefixFor(mode)}/quiz`, { method: "POST", body: payload, token });
-      return created?.id ? created : { ...payload, id: Math.max(0, ...items.map(i => i.id||0)) + 1 };
-    } catch {
-      return { ...payload, id: Math.max(0, ...items.map(i => i.id||0)) + 1 };
+      const created = await api.criarPergunta(payload);
+      return created?.id ? created : payload;
+    } catch (e) {
+      setErr(e.message || "Não foi possível criar a pergunta.");
+      throw e;
     }
   }
 
   async function updateItem(id, payload) {
-    try { await jsonFetch(`${prefixFor(mode)}/quiz/${id}`, { method: "PUT", body: payload, token }); }
-    catch {}
+    try {
+      const atualizado = await api.atualizarPergunta(id, payload);
+      return atualizado;
+    } catch (e) {
+      setErr(e.message || "Não foi possível atualizar a pergunta.");
+      throw e;
+    }
   }
 
   async function removeItem(id) {
-    try { await jsonFetch(`${prefixFor(mode)}/quiz/${id}`, { method: "DELETE", token }); }
-    catch {}
-    finally { setItems(prev => prev.filter(i => i.id !== id)); }
+    try {
+      await api.removerPergunta(id);
+      setItems(prev => prev.filter(i => i.id !== id));
+    } catch (e) {
+      setErr(e.message || "Não foi possível remover a pergunta.");
+    }
   }
 
-  useEffect(() => { load(); }, [mode]);
+  useEffect(() => {
+    load();
+  }, [mode]);
 
   const filtered = useMemo(() => {
     const query = q.trim().toLowerCase();
@@ -191,11 +168,15 @@ export default function QuizCRUD() {
         const created = await createItem(editing);
         setItems(prev => [...prev, created]);
       } else {
-        await updateItem(editing.id, editing);
-        setItems(prev => prev.map(it => (it.id === editing.id ? { ...editing } : it)));
+        const atualizado = await updateItem(editing.id, editing);
+        setItems(prev => prev.map(it => (it.id === editing.id ? { ...atualizado } : it)));
       }
       setEditing(null);
-    } finally { setSubmitting(false); }
+    } catch {
+      // erro já tratado acima
+    } finally {
+      setSubmitting(false);
+    }
   }
 
   return (

--- a/front/src/Ranking.css
+++ b/front/src/Ranking.css
@@ -38,6 +38,16 @@
   overflow: auto;          /* scroll no corpo */
 }
 
+.rk-error {
+  margin: 12px 0;
+  padding: 12px 16px;
+  border-radius: 12px;
+  background: rgba(255, 87, 87, 0.12);
+  color: #ff5757;
+  font-weight: 600;
+  text-align: center;
+}
+
 /* TABELA */
 .rk-table {
   width: 100%;

--- a/front/src/Ranking.js
+++ b/front/src/Ranking.js
@@ -1,19 +1,6 @@
-import { useMemo } from "react";
+import { useEffect, useMemo, useState } from "react";
+import { api } from "./api";
 import "./Ranking.css";
-
-
-const DEMO_ROWS = [
-  { user: "Maria", score: 980 },
-  { user: "Gabriel", score: 960 },
-  { user: "Ana", score: 930 },
-  { user: "João", score: 890 },
-  { user: "Carla", score: 870 },
-  { user: "Rafa", score: 850 },
-  { user: "Luiza", score: 830 },
-  { user: "Pedro", score: 820 },
-  { user: "Felipe", score: 810 },
-  { user: "Bianca", score: 800 },
-];
 
 function positionDecor(pos) {
   if (pos === 1) return { icon: "🏆", cls: "gold" };
@@ -28,12 +15,37 @@ function PositionBadge({ pos }) {
 }
 
 export default function Ranking() {
+  const [usuarios, setUsuarios] = useState([]);
+  const [erro, setErro] = useState("");
+
+  useEffect(() => {
+    async function carregar() {
+      setErro("");
+      try {
+        const data = await api.listarUsuarios();
+        const normalizados = Array.isArray(data)
+          ? data.map((u) => ({
+              user: u?.email || "Usuário",
+              score: u?.pontuacao ?? 0,
+            }))
+          : [];
+        setUsuarios(normalizados);
+      } catch (e) {
+        setErro(e.message || "Não foi possível carregar o ranking.");
+        setUsuarios([]);
+      }
+    }
+
+    carregar();
+  }, []);
+
   const rows = useMemo(
     () =>
-      [...DEMO_ROWS]
+      [...usuarios]
         .sort((a, b) => (b.score ?? 0) - (a.score ?? 0))
+        .slice(0, 10)
         .map((r, i) => ({ ...r, pos: i + 1 })),
-    []
+    [usuarios]
   );
 
   return (
@@ -42,6 +54,8 @@ export default function Ranking() {
         <header className="rk-head">
           <h2 className="rk-title">Ranking • Top 10</h2>
         </header>
+
+        {erro && <div className="rk-error">{erro}</div>}
 
         <div className="rk-table-wrap scrollable">
           <table className="rk-table compact">

--- a/front/src/api.js
+++ b/front/src/api.js
@@ -1,0 +1,81 @@
+const API_BASE_URL = "http://localhost:8089/api";
+
+async function request(path, { method = "GET", body } = {}) {
+  const res = await fetch(`${API_BASE_URL}${path}`, {
+    method,
+    headers: { "Content-Type": "application/json" },
+    body: body ? JSON.stringify(body) : undefined,
+  });
+
+  const text = await res.text();
+  let data = null;
+  try {
+    data = text ? JSON.parse(text) : null;
+  } catch (err) {
+    data = { raw: text };
+  }
+
+  if (!res.ok) {
+    const message = data?.message || data?.error || text || "Erro ao comunicar com o servidor.";
+    throw new Error(message);
+  }
+
+  return data;
+}
+
+function mapPerguntaDtoToModel(dto) {
+  return {
+    id: dto?.codigoPergunta ?? null,
+    text: dto?.pergunta ?? "",
+    options: [dto?.q1, dto?.q2, dto?.q3, dto?.q4].map((opt) => opt ?? ""),
+    correctIndex: dto?.indiceResposta ?? 0,
+    explanation: dto?.explicacao ?? "",
+  };
+}
+
+function mapPerguntaModelToDto(model) {
+  return {
+    codigoPergunta: model?.id ?? null,
+    pergunta: model?.text ?? "",
+    q1: model?.options?.[0] ?? "",
+    q2: model?.options?.[1] ?? "",
+    q3: model?.options?.[2] ?? "",
+    q4: model?.options?.[3] ?? "",
+    explicacao: model?.explanation ?? "",
+    indiceResposta: model?.correctIndex ?? 0,
+  };
+}
+
+export const api = {
+  login(email, senha) {
+    return request("/usuario/login", { method: "POST", body: { email, senha } });
+  },
+
+  registrarUsuario(usuario) {
+    return request("/usuario", { method: "POST", body: usuario });
+  },
+
+  listarUsuarios() {
+    return request("/usuario");
+  },
+
+  listarPerguntas() {
+    return request("/pergunta").then((items) =>
+      Array.isArray(items) ? items.map(mapPerguntaDtoToModel) : []
+    );
+  },
+
+  criarPergunta(model) {
+    const payload = mapPerguntaModelToDto(model);
+    return request("/pergunta", { method: "POST", body: payload }).then(mapPerguntaDtoToModel);
+  },
+
+  atualizarPergunta(id, model) {
+    const payload = mapPerguntaModelToDto({ ...model, id });
+    return request(`/pergunta/${id}`, { method: "PUT", body: payload }).then(mapPerguntaDtoToModel);
+  },
+
+  removerPergunta(id) {
+    return request(`/pergunta/${id}`, { method: "DELETE" });
+  },
+};


### PR DESCRIPTION
## Summary
- add a reusable API client for the Spring Boot backend and switch login/registration to real requests
- load quiz questions and ranking data from the backend and surface error feedback in the UI
- connect the quiz CRUD screens to Spring endpoints with server-side persistence

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68e1b8f4df6c832095d961394972f60b