### PR TITLE
Integrate frontend REST calls with backend

### DIFF
--- a/front/src/Cadastro.js
+++ b/front/src/Cadastro.js
@@ -1,20 +1,7 @@
 import { useState } from "react";
 import { useNavigate, Link } from "react-router-dom";
-import "./Login.css"; 
-
-
-async function jsonPost(url, body) {
-  const res = await fetch(url, {
-    method: "POST",
-    headers: { "Content-Type": "application/json" },
-    body: JSON.stringify(body || {}),
-  });
-  const text = await res.text();
-  let data = null;
-  try { data = text ? JSON.parse(text) : null; } catch { data = { raw: text }; }
-  if (!res.ok) throw new Error(`HTTP ${res.status}: ${text}`);
-  return data;
-}
+import { api } from "./api";
+import "./Login.css";
 
 export default function Cadastro() {
   const [name, setName] = useState("");
@@ -23,11 +10,13 @@ export default function Cadastro() {
   const [passReg2, setPassReg2] = useState("");
   const [ok, setOk] = useState("");
   const [err, setErr] = useState("");
+  const [loading, setLoading] = useState(false);
 
   const navigate = useNavigate();
 
-  async function doRegister(mode) {
-    setErr(""); setOk("");
+  async function doRegisterRest() {
+    setErr("");
+    setOk("");
 
     if (!name || !emailReg || !passReg || !passReg2) {
       setErr("Preencha todos os campos.");
@@ -38,34 +27,30 @@ export default function Cadastro() {
       return;
     }
 
-    
-    const prefix = mode === "grpc" ? "/grpc" : "/rest";
-
+    setLoading(true);
     try {
-      
-      
-      await jsonPost(`${prefix}/auth/register`, {
-        name,
+      await api.registrarUsuario({
         email: emailReg,
-        password: passReg,
+        senha: passReg,
+        pontuacao: 0,
       });
 
-      
-  localStorage.setItem("apiMode", mode);            
-      localStorage.setItem("basePrefix", prefix);
+      localStorage.setItem("apiMode", "rest");
+      localStorage.setItem("basePrefix", "/rest");
       localStorage.setItem("demoUser", JSON.stringify({ name, email: emailReg }));
 
-      setOk(`Conta criada com sucesso via ${mode.toUpperCase()}!`);
+      setOk("Conta criada com sucesso via REST!");
       setTimeout(() => navigate("/login", { replace: true }), 900);
-    } catch (e) {
-      
-      localStorage.setItem("apiMode", mode);
-      localStorage.setItem("basePrefix", prefix);
-      localStorage.setItem("demoUser", JSON.stringify({ name, email: emailReg }));
-
-      setOk(`Conta criada (demo) via ${mode.toUpperCase()}.`);
-      setTimeout(() => navigate("/login", { replace: true }), 900);
+    } catch (error) {
+      setErr(error?.message || "Não foi possível criar a conta.");
+    } finally {
+      setLoading(false);
     }
+  }
+
+  function showGrpcMessage() {
+    setErr("Integração gRPC ainda não está disponível.");
+    setOk("");
   }
 
   return (
@@ -110,11 +95,11 @@ export default function Cadastro() {
 
         
         <div className="btn-row">
-          <button className="btn-login" type="button" onClick={() => doRegister("grpc")}>
+          <button className="btn-login" type="button" onClick={showGrpcMessage} disabled={loading}>
             Criar conta com gRPC
           </button>
-          <button className="btn-login outline" type="button" onClick={() => doRegister("rest")}>
-            Criar conta com REST
+          <button className="btn-login outline" type="button" onClick={doRegisterRest} disabled={loading}>
+            {loading ? "Criando..." : "Criar conta com REST"}
           </button>
         </div>
 

--- a/front/src/QuizCRUD.js
+++ b/front/src/QuizCRUD.js
@@ -1,73 +1,29 @@
 import { useEffect, useMemo, useState } from "react";
 import "./QuizCRUD.css";
+import { api } from "./api";
 
-const REST_PREFIX = "/rest";
-const GRPC_PREFIX = "/grpc";
+const EMPTY_QUESTION = {
+  id: null,
+  text: "",
+  options: ["", "", "", ""],
+  correctIndex: 0,
+  explanation: "",
+};
 
+function QuestionForm({ value, onChange, onSubmit, onCancel, submitting }) {
+  const v = value || EMPTY_QUESTION;
+  const options = v.options || ["", "", "", ""];
 
-function prefixFor(mode) {
-  return mode === "rest" ? REST_PREFIX : GRPC_PREFIX;
-}
-async function jsonFetch(url, { method = "GET", body, token } = {}) {
-  const headers = { "Content-Type": "application/json" };
-  if (token) headers["Authorization"] = `Bearer ${token}`;
-  const res = await fetch(url, { method, headers, body: body ? JSON.stringify(body) : undefined });
-  const text = await res.text();
-  let data = null;
-  try { data = text ? JSON.parse(text) : null; } catch { data = { raw: text }; }
-  if (!res.ok) throw new Error(`HTTP ${res.status}: ${text}`);
-  return data;
-}
+  function set(field, val) {
+    onChange({ ...v, [field]: val });
+  }
 
-
-const DEMO_DATA = [
-  {
-    id: 1,
-    text: "O que é gRPC?",
-    options: ["Protocolo de roteamento", "Framework RPC", "Banco de dados", "Balanceador"],
-    correctIndex: 1,
-    explanation: "gRPC é um framework RPC de alto desempenho baseado em HTTP/2 e Protobuf.",
-  },
-  {
-    id: 2,
-    text: "Qual protocolo de transporte o gRPC usa por padrão?",
-    options: ["HTTP/1.1", "WebSocket", "HTTP/2", "FTP"],
-    correctIndex: 2,
-    explanation: "gRPC usa HTTP/2 por padrão.",
-  },
-];
-
-
-function ModeToggle({ mode, setMode }) {
-  return (
-    <div className="crud-toggle">
-      <button
-        type="button"
-        className={mode === "rest" ? "crud-btn active" : "crud-btn"}
-        onClick={() => setMode("rest")}
-      >
-        REST
-      </button>
-      <button
-        type="button"
-        className={mode === "grpc" ? "crud-btn active" : "crud-btn"}
-        onClick={() => setMode("grpc")}
-      >
-        gRPC
-      </button>
-    </div>
-  );
-}
-
-
-function QuestionForm({ value, onChange, onSubmit, onCancel, submitting, mode }) {
-  const v = value;
-  function set(field, val) { onChange({ ...v, [field]: val }); }
   function setOption(idx, val) {
-    const opts = [...v.options];
+    const opts = [...options];
     opts[idx] = val;
     onChange({ ...v, options: opts });
   }
+
   return (
     <form className="crud-form" onSubmit={onSubmit}>
       <label className="crud-label">Texto da questão</label>
@@ -85,7 +41,7 @@ function QuestionForm({ value, onChange, onSubmit, onCancel, submitting, mode })
           <label className="crud-label">Alternativa {letra}</label>
           <input
             className="crud-input"
-            value={v.options[i]}
+            value={options[i] || ""}
             onChange={(e) => setOption(i, e.target.value)}
             required
           />
@@ -99,7 +55,9 @@ function QuestionForm({ value, onChange, onSubmit, onCancel, submitting, mode })
         min={0}
         max={3}
         value={v.correctIndex}
-        onChange={(e) => set("correctIndex", Math.max(0, Math.min(3, Number(e.target.value))))}
+        onChange={(e) =>
+          set("correctIndex", Math.max(0, Math.min(3, Number(e.target.value))))
+        }
       />
 
       <label className="crud-label">Explicação</label>
@@ -112,9 +70,7 @@ function QuestionForm({ value, onChange, onSubmit, onCancel, submitting, mode })
 
       <div className="crud-actions">
         <button className="crud-btn primary" disabled={submitting} type="submit">
-          {submitting
-            ? `Salvando (${mode === "rest" ? "REST" : "gRPC"})...`
-            : `Salvar (${mode === "rest" ? "REST" : "gRPC"})`}
+          {submitting ? "Salvando (REST)..." : "Salvar (REST)"}
         </button>
         <button className="crud-btn outline" type="button" onClick={onCancel}>
           Cancelar
@@ -124,78 +80,86 @@ function QuestionForm({ value, onChange, onSubmit, onCancel, submitting, mode })
   );
 }
 
-
 export default function QuizCRUD() {
-  const [mode, setMode] = useState("grpc");
   const [items, setItems] = useState([]);
   const [q, setQ] = useState("");
   const [loading, setLoading] = useState(false);
   const [err, setErr] = useState("");
   const [editing, setEditing] = useState(null);
   const [submitting, setSubmitting] = useState(false);
-  const token = typeof localStorage !== "undefined" ? localStorage.getItem("token") || "" : "";
 
   async function load() {
-    setErr(""); setLoading(true);
+    setLoading(true);
+    setErr("");
     try {
-      const data = await jsonFetch(`${prefixFor(mode)}/quiz`, { token });
-      const arr = Array.isArray(data) ? data : (data?.items || []);
+      const data = await api.listarPerguntas();
+      const arr = Array.isArray(data) ? data : [];
       setItems(arr);
-    } catch {
-      setItems(DEMO_DATA);
-      setErr("(demo) usando dados locais, não consegui buscar no backend.");
-    } finally { setLoading(false); }
-  }
-
-  async function createItem(payload) {
-    try {
-      const created = await jsonFetch(`${prefixFor(mode)}/quiz`, { method: "POST", body: payload, token });
-      return created?.id ? created : { ...payload, id: Math.max(0, ...items.map(i => i.id||0)) + 1 };
-    } catch {
-      return { ...payload, id: Math.max(0, ...items.map(i => i.id||0)) + 1 };
+    } catch (error) {
+      setItems([]);
+      setErr(error?.message || "Não foi possível carregar as perguntas.");
+    } finally {
+      setLoading(false);
     }
   }
 
-  async function updateItem(id, payload) {
-    try { await jsonFetch(`${prefixFor(mode)}/quiz/${id}`, { method: "PUT", body: payload, token }); }
-    catch {}
-  }
-
-  async function removeItem(id) {
-    try { await jsonFetch(`${prefixFor(mode)}/quiz/${id}`, { method: "DELETE", token }); }
-    catch {}
-    finally { setItems(prev => prev.filter(i => i.id !== id)); }
-  }
-
-  useEffect(() => { load(); }, [mode]);
+  useEffect(() => {
+    load();
+  }, []);
 
   const filtered = useMemo(() => {
     const query = q.trim().toLowerCase();
     if (!query) return items;
-    return items.filter(it =>
+    return items.filter((it) =>
       it.text?.toLowerCase().includes(query) ||
       it.explanation?.toLowerCase().includes(query) ||
-      (it.options || []).some(o => o?.toLowerCase().includes(query))
+      (it.options || []).some((o) => o?.toLowerCase().includes(query))
     );
   }, [items, q]);
 
-  function newEmpty() {
-    setEditing({ id: null, text: "", options: ["", "", "", ""], correctIndex: 0, explanation: "" });
+  function startCreate() {
+    setEditing({ ...EMPTY_QUESTION });
+  }
+
+  function startEdit(item) {
+    setEditing({ ...item, options: [...(item.options || ["", "", "", ""])] });
   }
 
   async function submitForm(e) {
     e.preventDefault();
+    if (!editing) return;
     setSubmitting(true);
+    setErr("");
+
     try {
       if (editing.id == null) {
-        const created = await createItem(editing);
-        setItems(prev => [...prev, created]);
+        const created = await api.criarPergunta(editing);
+        setItems((prev) => [...prev, created]);
       } else {
-        await updateItem(editing.id, editing);
-        setItems(prev => prev.map(it => (it.id === editing.id ? { ...editing } : it)));
+        const updated = await api.atualizarPergunta(editing.id, editing);
+        setItems((prev) =>
+          prev.map((it) => (it.id === updated.id ? updated : it))
+        );
       }
       setEditing(null);
-    } finally { setSubmitting(false); }
+    } catch (error) {
+      setErr(error?.message || "Erro ao salvar a pergunta.");
+    } finally {
+      setSubmitting(false);
+    }
+  }
+
+  async function removeItem(id) {
+    if (!window.confirm("Deseja excluir esta pergunta?")) {
+      return;
+    }
+    setErr("");
+    try {
+      await api.removerPergunta(id);
+      setItems((prev) => prev.filter((it) => it.id !== id));
+    } catch (error) {
+      setErr(error?.message || "Não foi possível excluir a pergunta.");
+    }
   }
 
   return (
@@ -204,17 +168,18 @@ export default function QuizCRUD() {
         <header className="crud-head">
           <div>
             <h2 className="crud-title">CRUD de Quiz</h2>
-            <p className="crud-subtle">Gerencie questões: criar, editar e excluir</p>
+            <p className="crud-subtle">
+              Integração REST ativa. A opção gRPC permanece indisponível.
+            </p>
           </div>
 
           {!editing && (
             <div className="crud-actions-right">
-              <ModeToggle mode={mode} setMode={setMode} />
-              <button className="crud-btn primary" onClick={newEmpty}>+ Nova questão</button>
+              <button className="crud-btn primary" onClick={startCreate}>
+                + Nova questão
+              </button>
               <button className="crud-btn" onClick={load} disabled={loading}>
-                {loading
-                  ? `Atualizando (${mode === "rest" ? "REST" : "gRPC"})...`
-                  : `Atualizar (${mode === "rest" ? "REST" : "gRPC"})`}
+                {loading ? "Atualizando (REST)..." : "Atualizar (REST)"}
               </button>
             </div>
           )}
@@ -240,7 +205,6 @@ export default function QuizCRUD() {
             onSubmit={submitForm}
             onCancel={() => setEditing(null)}
             submitting={submitting}
-            mode={mode}
           />
         ) : (
           <div className="crud-table-wrap">
@@ -255,16 +219,27 @@ export default function QuizCRUD() {
               </thead>
               <tbody>
                 {filtered.length === 0 ? (
-                  <tr><td colSpan={4} className="empty">Sem resultados.</td></tr>
+                  <tr>
+                    <td colSpan={4} className="empty">
+                      {loading
+                        ? "Carregando perguntas..."
+                        : "Sem resultados."}
+                    </td>
+                  </tr>
                 ) : (
-                  filtered.map(it => (
+                  filtered.map((it) => (
                     <tr key={it.id}>
                       <td>{it.id}</td>
                       <td>
                         <div className="q-text">{it.text}</div>
                         <div className="q-options">
                           {it.options?.map((op, idx) => (
-                            <span key={idx} className={`q-badge ${idx === it.correctIndex ? "ok" : ""}`}>
+                            <span
+                              key={idx}
+                              className={`q-badge ${
+                                idx === it.correctIndex ? "ok" : ""
+                              }`}
+                            >
                               {String.fromCharCode(65 + idx)}. {op}
                             </span>
                           ))}
@@ -272,13 +247,22 @@ export default function QuizCRUD() {
                       </td>
                       <td>
                         {typeof it.correctIndex === "number"
-                          ? `Índice ${it.correctIndex} (${String.fromCharCode(65 + it.correctIndex)})`
+                          ? `Índice ${it.correctIndex} (${String.fromCharCode(
+                              65 + it.correctIndex
+                            )})`
                           : "-"}
                       </td>
                       <td>
                         <div className="row-actions">
-                          <button className="crud-btn" onClick={() => setEditing({ ...it })}>Editar</button>
-                          <button className="crud-btn danger" onClick={() => removeItem(it.id)}>Excluir</button>
+                          <button className="crud-btn" onClick={() => startEdit(it)}>
+                            Editar
+                          </button>
+                          <button
+                            className="crud-btn danger"
+                            onClick={() => removeItem(it.id)}
+                          >
+                            Excluir
+                          </button>
                         </div>
                       </td>
                     </tr>
@@ -288,7 +272,6 @@ export default function QuizCRUD() {
             </table>
           </div>
         )}
-
       </section>
     </div>
   );


### PR DESCRIPTION
## Summary
- hook login and registration flows to the REST API while leaving gRPC disabled
- load quiz gameplay data directly from the backend and handle REST-only interactions
- wire the quiz CRUD interface to create, update, and delete questions via REST endpoints

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68e1c2bb946c83209fb12b6080dd7f89